### PR TITLE
Change Display of Anime

### DIFF
--- a/src/discord-RPC/discord_rpc_functions.cpp
+++ b/src/discord-RPC/discord_rpc_functions.cpp
@@ -44,7 +44,14 @@ namespace discord
       sprintf_s(tmpString, sizeof(char) * anime_name_len, "%ls", anime_name.c_str());
       discordPresence.details = tmpString;
       char* state = new char[255];
-      sprintf_s(state, sizeof(char) * 255, "Episode %d of %d", episode_number, episode_count);
+      if (episode_count == 0)
+      {
+        sprintf_s(state, sizeof(char) * 255, "Episode %d", episode_number);
+      }
+      else
+      {
+        sprintf_s(state, sizeof(char) * 255, "Episode %d of %d", episode_number, episode_count);
+      }
       discordPresence.state = state;
       discordPresence.startTimestamp = time(0);
       Discord_UpdatePresence(&discordPresence);

--- a/src/discord-RPC/discord_rpc_functions.cpp
+++ b/src/discord-RPC/discord_rpc_functions.cpp
@@ -25,28 +25,32 @@ namespace discord
   //  discordPresence.details = "Watching something";
   //  Discord_UpdatePresence(&discordPresence);
   //}
-
-  void updateDiscordPresence(bool idling, const std::wstring& anime_name)
+  void updateDiscordPresence(bool idling, const std::wstring& anime_name, const int episode_number, const int episode_count)
   {
-    DiscordRichPresence discordPresence;
-    memset(&discordPresence, 0, sizeof(discordPresence));
+   
     //discordPresence.state = "Taiga Discord Test";
     //discordPresence.details = "Watching something";
 
     if (idling)
     {
-      discordPresence.details = "Idling";
+      Discord_ClearPresence();
     }
     else
     {
-      discordPresence.details = "Watching Anime";
-      char* tmpString = new char[255];
-      sprintf_s(tmpString, sizeof(char) * 255, "%ls", anime_name.c_str());
-      discordPresence.state = tmpString;
+      DiscordRichPresence discordPresence;
+      memset(&discordPresence, 0, sizeof(discordPresence));
+      size_t anime_name_len = anime_name.size() + (size_t) 1;
+      char* tmpString = new char[anime_name_len];
+      sprintf_s(tmpString, sizeof(char) * anime_name_len, "%ls", anime_name.c_str());
+      discordPresence.details = tmpString;
+      char* state = new char[255];
+      sprintf_s(state, sizeof(char) * 255, "Episode %d of %d", episode_number, episode_count);
+      discordPresence.state = state;
       discordPresence.startTimestamp = time(0);
+      Discord_UpdatePresence(&discordPresence);
+
     }
 
-    Discord_UpdatePresence(&discordPresence);
   }
 
   static void handleDiscordReady(void)

--- a/src/discord-RPC/discord_rpc_functions.h
+++ b/src/discord-RPC/discord_rpc_functions.h
@@ -7,7 +7,7 @@ namespace discord
   inline const char* APPLICATION_ID = "419764858976993280";
 
   void discordInit();
-  void updateDiscordPresence(bool idling = true, const std::wstring& animeName = L"");
+  void updateDiscordPresence(bool idling = true, const std::wstring& animeName = L"", const int episode_number = 0, const int episode_count = 0);
   void handleDiscordReady(void);
   void handleDiscordDisconnected(int errcode, const char* message);
   void handleDiscordError(int errcode, const char* message);

--- a/src/ui/ui.cpp
+++ b/src/ui/ui.cpp
@@ -658,8 +658,8 @@ void OnAnimeWatchingStart(const anime::Item& anime_item,
     taskbar.Tip(L"", L"", 0);
     taskbar.Tip(tip_text.c_str(), L"Now Playing", NIIF_INFO | NIIF_NOSOUND);
   }
+  discord::updateDiscordPresence(false, anime_item.GetEnglishTitle(true), episode.episode_number(), anime_item.GetEpisodeCount());
 
-  discord::updateDiscordPresence(false, anime_item.GetEnglishTitle(true) + L" Episode " + std::to_wstring(episode.episode_number()));
 }
 
 void OnAnimeWatchingEnd(const anime::Item& anime_item,


### PR DESCRIPTION
Changes "details" to the name of the show, and "state" to the current episode number. Also clears the currently playing status when not watching anime instead of changing it to "idling"

Here's a preview. I've changed the app ID to my own app called "Anime", but that's not in this commit.

![taiga](https://user-images.githubusercontent.com/517314/37247287-0c8c7822-2487-11e8-93a2-97df2c218ea1.PNG)
